### PR TITLE
fix unquoted basename $0 -> basename "$0"

### DIFF
--- a/pdfScale.sh
+++ b/pdfScale.sh
@@ -20,7 +20,7 @@
 #
 ################################################################
 
-VERSION="2.5.5"
+VERSION="2.5.6"
 
 
 ###################### EXTERNAL PROGRAMS #######################
@@ -45,11 +45,11 @@ FALSE=1
 
 ########################### GLOBALS ############################
 
-SCALE="0.95"                   # scaling factor (0.95 = 95%, e.g.)
-VERBOSE=0                      # verbosity Level
-PDFSCALE_NAME="$(basename $0)" # simplified name of this script
-OSNAME="$(uname 2>/dev/null)"  # Check where we are running
-GS_RUN_STATUS=""               # Holds GS error messages, signals errors
+SCALE="0.95"                     # scaling factor (0.95 = 95%, e.g.)
+VERBOSE=0                        # verbosity Level
+PDFSCALE_NAME="$(basename "$0")" # simplified name of this script
+OSNAME="$(uname 2>/dev/null)"    # Check where we are running
+GS_RUN_STATUS=""                 # Holds GS error messages, signals errors
 
 INFILEPDF=""                # Input PDF file name
 OUTFILEPDF=""               # Output PDF file name


### PR DESCRIPTION
When using script in a folder with spaces error "basename extra operand" appears because path is not properly double quoted.