### PR TITLE
Add windows tips in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -470,6 +470,14 @@ sudo yum install imagemagick pdfinfo
 brew install imagemagick xpdf
 ```
   
+## Windows
+
+- The script should work fine in cygwin.
+- If you are using msys/git for windows, and the script exits with a 'file not found' error,
+- try running `export MSYS_NO_PATHCONV=1`
+- and `export MSYS2_ARG_CONV_EXCL="*"`
+- and then running again.
+
 ## Clone using git
 ```
 git clone https://github.com/tavinus/pdfScale.git


### PR DESCRIPTION
This workaround resolved the file-not-found errors I got otherwise.

(What's happening is that when there are parameters beginning with a leading slash like `/Bicubic` , msys mistakenly thinks it is a filepath and adds a prefix. The exported flags turn off that behavior (for git-for-windows and msys2 at least, vanilla msys1 still might run into the problem).)